### PR TITLE
Update to use tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,17 @@ repository = "https://github.com/xi-frontend/xrl"
 version = "0.0.5"
 
 [dependencies]
-bytes = "0.4.5"
-futures = "0.1.16"
-log = "0.3.8"
-serde = "1.0.15"
-serde_derive = "1.0.15"
-serde_json = "1.0.3"
-tokio-core = "0.1.10"
-tokio-io = "0.1.3"
-tokio-process = "0.1.4"
-syntect = { version = "1.8.1", default-features = false}
+bytes = "0.4.8"
+futures = "0.1.23"
+log = "0.4.3"
+serde = "1.0.70"
+serde_derive = "1.0.70"
+serde_json = "1.0.24"
+tokio = "0.1.7"
+tokio-codec = "0.1.0"
+tokio-process = "0.2.2"
+syntect = { version = "2.1.0", default-features = false}
 
 [dependencies.clippy]
 optional = true
-version = "0.0.193"
+version = "0.0.212"

--- a/examples/it_works.rs
+++ b/examples/it_works.rs
@@ -76,7 +76,7 @@ fn main() {
 
     // spawn Xi core
     let (mut client, core_stderr) = spawn("xi-core", MyFrontendBuilder {}, &handle);
-
+    core.run(client.client_started(None, None).map_err(|_|()));
     // start logging Xi core's stderr
     let log_core_errors = core_stderr
         .for_each(|msg| {

--- a/examples/it_works.rs
+++ b/examples/it_works.rs
@@ -1,10 +1,9 @@
 #![allow(unused_variables)]
 extern crate futures;
-extern crate tokio_core;
+extern crate tokio;
 extern crate xrl;
 
 use futures::{future, Future, Stream};
-use tokio_core::reactor::Core;
 use xrl::{
     Update, ScrollTo, Style,
     AvailablePlugins, UpdateCmds,
@@ -71,24 +70,26 @@ impl FrontendBuilder<MyFrontend> for MyFrontendBuilder {
 }
 
 fn main() {
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
-
     // spawn Xi core
-    let (mut client, core_stderr) = spawn("xi-core", MyFrontendBuilder {}, &handle);
-    core.run(client.client_started(None, None).map_err(|_|()));
+    let (mut client, core_stderr) = spawn("xi-core", MyFrontendBuilder {});
+
+    // All clients must send client_started notification first
+    tokio::run(client.client_started(None, None).map_err(|_|()));
     // start logging Xi core's stderr
     let log_core_errors = core_stderr
         .for_each(|msg| {
             println!("xi-core stderr: {}", msg);
             Ok(())
-        })
-        .map_err(|_| ());
-    core.handle().spawn(log_core_errors);
-
+        }).map_err(|_|());
+    ::std::thread::spawn(move || {
+        tokio::run(log_core_errors);
+    });
     // Send a request to open a new view, and print the result
     let open_new_view = client
         .new_view(None)
-        .map(|view_name| println!("opened new view: {}", view_name));
-    core.run(open_new_view).unwrap();
+        .map(|view_name| println!("opened new view: {}", view_name))
+        .map_err(|_|());
+    tokio::run(open_new_view);
+    // sleep until xi-requests are received
+    ::std::thread::sleep(::std::time::Duration::new(5, 0));
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,5 +1,6 @@
 use {Line, Operation, OperationType, Update};
 
+/// Line cache struct to work with xi update protocol.
 #[derive(Clone, Debug, Default)]
 pub struct LineCache {
     invalid_before: u64,
@@ -9,18 +10,24 @@ pub struct LineCache {
 
 impl LineCache {
 
+    /// Retrieve the number of invalid lines before
+    /// the start of the line cache.
     pub fn before(&self) -> u64 {
         self.invalid_before
     }
 
+    /// Retrieve the number of invalid lines after
+    /// the line cache.
     pub fn after(&self) -> u64 {
         self.invalid_after
     }
 
+    /// Retrieve all lines in the cache.
     pub fn lines(&self) -> &Vec<Line> {
         &self.lines
     }
 
+    /// Handle an xi-core update.
     pub fn update(&mut self, update: Update) {
         let LineCache {
             ref mut lines,

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use structs::ViewId;
 
 /// A future returned by all the `Client`'s method.
-pub type ClientResult<T> = Box<Future<Item = T, Error = ClientError>>;
+pub type ClientResult<T> = Box<Future<Item = T, Error = ClientError> + Send>;
 
 /// A client to send notifications and request to xi-core.
 #[derive(Clone)]
@@ -75,7 +75,7 @@ impl Client {
     }
 
     /// Send an "scroll" notification
-    /// ```
+    /// ```ignore
     /// {"method":"edit","params":{"method":"scroll","params":[21,80],
     /// "view_id":"view-id-1"}}
     /// ```
@@ -221,7 +221,7 @@ impl Client {
     }
 
     /// send a `"new_view"` request to the core.
-    /// ```
+    /// ```ignore
     /// {"id":1,"method":"new_view","params":{"file_path":"foo/test.txt"}}
     /// ```
     pub fn new_view(&mut self, file_path: Option<String>) -> ClientResult<ViewId> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,7 @@ use structs::ViewId;
 /// A future returned by all the `Client`'s method.
 pub type ClientResult<T> = Box<Future<Item = T, Error = ClientError>>;
 
-/// A client to send notifications and request to the core
+/// A client to send notifications and request to xi-core.
 #[derive(Clone)]
 pub struct Client(pub protocol::Client);
 
@@ -142,7 +142,7 @@ impl Client {
     pub fn del(&mut self, view_id: ViewId) -> ClientResult<()> {
         self.edit(view_id, "delete_backward", None as Option<Value>)
     }
-    
+
     pub fn page_up(&mut self, view_id: ViewId) -> ClientResult<()> {
         self.edit(view_id, "scroll_page_up", None as Option<Value>)
     }
@@ -190,7 +190,7 @@ impl Client {
             None as Option<Value>,
         )
     }
-    
+
     pub fn select_all(&mut self, view_id: ViewId) -> ClientResult<()> {
         self.edit(view_id, "select_all", None as Option<Value>)
     }

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -43,7 +43,7 @@ where
     fn build(self, client: Client) -> F;
 }
 
-impl<F: Frontend> Service for F {
+impl<F: Frontend + Send> Service for F {
     type T = Value;
     type E = Value;
     type Error = ServerError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,14 +29,38 @@
 //!         // to the core here with `self.client`
 //!         Box::new(future::ok(()))
 //!     }
+//!
 //!     fn scroll_to(&mut self, scroll_to: ScrollTo) -> ServerResult<()> {
 //!         println!("received `scroll_to` from Xi core:\n{:?}", scroll_to);
 //!         Box::new(future::ok(()))
 //!     }
+//!
 //!     fn def_style(&mut self, style: Style) -> ServerResult<()> {
 //!         println!("received `set_style` from Xi core:\n{:?}", style);
 //!         Box::new(future::ok(()))
 //!     }
+//!
+//!    fn available_plugins(&mut self, plugins: AvailablePlugins) -> ServerResult<()> {
+//!        Box::new(future::ok(()))
+//!    }
+//!
+//!    fn update_cmds(&mut self, plugins: UpdateCmds) -> ServerResult<()> {
+//!        Box::new(future::ok(()))
+//!    }
+//!
+//!    fn plugin_started(&mut self, plugins: PluginStarted) -> ServerResult<()> {
+//!        Box::new(future::ok(()))
+//!    }
+//!
+//!    fn plugin_stoped(&mut self, plugin: PluginStoped) -> ServerResult<()> {
+//!        Box::new(future::ok(()))
+//!    }
+//!    fn config_changed(&mut self, config: ConfigChanged) -> ServerResult<()> {
+//!        Box::new(future::ok(()))
+//!    }
+//!    fn theme_changed(&mut self, theme: ThemeChanged) -> ServerResult<()> {
+//!        Box::new(future::ok(()))
+//!    }
 //! }
 //!
 //! struct MyFrontendBuilder;

--- a/src/protocol/codec.rs
+++ b/src/protocol/codec.rs
@@ -1,6 +1,6 @@
 use std::io;
 use bytes::{BufMut, BytesMut};
-use tokio_io::codec::{Decoder, Encoder};
+use tokio_codec::{Decoder, Encoder};
 
 use super::errors::DecodeError;
 use super::message::Message;

--- a/src/structs/scroll_to.rs
+++ b/src/structs/scroll_to.rs
@@ -11,13 +11,14 @@ pub struct ScrollTo {
 #[test]
 fn deserialize_ok() {
     use serde_json;
+    use std::str::FromStr;
 
     let s = r#"{"col":18,"line":0,"view_id":"view-id-1"}"#;
     let deserialized: Result<ScrollTo, _> = serde_json::from_str(s);
     let scroll_to = ScrollTo {
         line: 0,
         column: 18,
-        view_id: "view-id-1".to_string(),
+        view_id: FromStr::from_str("view-id-1").unwrap(),
     };
     assert_eq!(deserialized.unwrap(), scroll_to);
 }

--- a/src/structs/update.rs
+++ b/src/structs/update.rs
@@ -45,7 +45,8 @@ impl<'de> Deserialize<'de> for Update {
 #[test]
 fn deserialize_update() {
     use serde_json;
-
+    use std::str::FromStr;
+    
     use super::Line;
     use super::operation::{Operation, OperationType};
 
@@ -77,7 +78,7 @@ fn deserialize_update() {
         ],
         pristine: true,
         rev: None,
-        view_id: "view-id-1".to_string(),
+        view_id: FromStr::from_str("view-id-1").unwrap(),
     };
     let deserialized: Result<Update, _> = serde_json::from_str(s);
     assert_eq!(deserialized.unwrap(), update);


### PR DESCRIPTION
use 'tokio' instead of 'tokio-core' and 'tokio-io', also update the examples and add a few doc comments. I would like to investigate the clippy build failing before this is merged.