### PR TITLE
Fix tabs in xi term (mostly)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -309,6 +309,10 @@ impl Client {
         self.edit_notify(view_id, "insert_newline", None as Option<Value>)
     }
 
+    pub fn insert_tab(&mut self, view_id: ViewId) -> ClientResult<()> {
+        self.edit_notify(view_id, "insert_tab", None as Option<Value>)
+    }
+
     pub fn f1(&mut self, view_id: ViewId) -> ClientResult<()> {
         self.edit_notify(view_id, "debug_rewrap", None as Option<Value>)
     }

--- a/src/structs/config.rs
+++ b/src/structs/config.rs
@@ -2,16 +2,16 @@ use ViewId;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ConfigChanged {
-    view_id: ViewId,
-    changes: ConfigChanges
+    pub view_id: ViewId,
+    pub changes: ConfigChanges
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ConfigChanges {
-    font_face: Option<String>,
-    font_size: Option<u64>,
-    line_ending: Option<String>,
-    plugin_search_path: Option<Vec<String>>,
-    tab_size: Option<u64>,
-    translate_tabs_to_spaces: Option<bool>,
+    pub font_face: Option<String>,
+    pub font_size: Option<u64>,
+    pub line_ending: Option<String>,
+    pub plugin_search_path: Option<Vec<String>>,
+    pub tab_size: Option<u64>,
+    pub translate_tabs_to_spaces: Option<bool>,
 }


### PR DESCRIPTION
Xi-term has [issues](https://github.com/xi-frontend/xi-term/issues/80) when the terminal tab width is not set to 4. While these two changes won't fix the problem entirely, it should reduce the frequency users run into this somewhat (and offer up an alternative means for fixing the underlying problem if they do run into it).

First, we'll notify xi-core when we insert a tab. If we're lucky, the user has enabled the translate_tabs_to_spaces config option, and our problems go away automatically: no tabs mean no mismatches.

If the user must stick with tabs, we can at least provide a way to configure xi-term to match the terminal, rather than the other way around.