### PR TITLE
Add collapse-selections

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -305,6 +305,10 @@ impl Client {
         self.edit_notify(view_id, "select_all", None as Option<Value>)
     }
 
+    pub fn collapse_selections(&mut self, view_id: ViewId) -> ClientResult<()> {
+        self.edit_notify(view_id, "collapse_selections", None as Option<Value>)
+    }
+
     pub fn insert_newline(&mut self, view_id: ViewId) -> ClientResult<()> {
         self.edit_notify(view_id, "insert_newline", None as Option<Value>)
     }


### PR DESCRIPTION
Removes all current selections, this was recently [changed](https://github.com/xi-editor/xi-editor/pull/1016), although not implemented by xrl anyway. 
Typical use case would be the escape key. 
