### PR TITLE
 Add newer gesture commands for click input 

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -305,6 +305,10 @@ impl Client {
         self.edit_notify(view_id, "select_all", None as Option<Value>)
     }
 
+    pub fn collapse_selections(&mut self, view_id: ViewId) -> ClientResult<()> {
+        self.edit_notify(view_id, "collapse_selections", None as Option<Value>)
+    }
+
     pub fn insert_newline(&mut self, view_id: ViewId) -> ClientResult<()> {
         self.edit_notify(view_id, "insert_newline", None as Option<Value>)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -334,6 +334,104 @@ impl Client {
         self.edit_notify(view_id, "click", Some(json!([line, column, 0, 1])))
     }
 
+    pub fn click_point_select(
+        &mut self,
+        view_id: ViewId,
+        line: u64,
+        column: u64,
+    ) -> ClientResult<()> {
+        let ty = "point_select";
+        self.edit_notify(
+            view_id,
+            "gesture",
+            Some(json!({"line": line, "col": column, "ty": ty,})),
+        )
+    }
+
+    pub fn click_toggle_sel(
+        &mut self,
+        view_id: ViewId,
+        line: u64,
+        column: u64,
+    ) -> ClientResult<()> {
+        let ty = "toggle_sel";
+        self.edit_notify(
+            view_id,
+            "gesture",
+            Some(json!({"line": line, "col": column, "ty": ty,})),
+        )
+    }
+
+    pub fn click_range_select(
+        &mut self,
+        view_id: ViewId,
+        line: u64,
+        column: u64,
+    ) -> ClientResult<()> {
+        let ty = "range_select";
+        self.edit_notify(
+            view_id,
+            "gesture",
+            Some(json!({"line": line, "col": column, "ty": ty,})),
+        )
+    }
+
+    pub fn click_line_select(
+        &mut self,
+        view_id: ViewId,
+        line: u64,
+        column: u64,
+    ) -> ClientResult<()> {
+        let ty = "range_select";
+        self.edit_notify(
+            view_id,
+            "gesture",
+            Some(json!({"line": line, "col": column, "ty": ty,})),
+        )
+    }
+
+    pub fn click_word_select(
+        &mut self,
+        view_id: ViewId,
+        line: u64,
+        column: u64,
+    ) -> ClientResult<()> {
+        let ty = "word_select";
+        self.edit_notify(
+            view_id,
+            "gesture",
+            Some(json!({"line": line, "col": column, "ty": ty,})),
+        )
+    }
+
+    pub fn click_multi_line_select(
+        &mut self,
+        view_id: ViewId,
+        line: u64,
+        column: u64,
+    ) -> ClientResult<()> {
+        let ty = "multi_line_select";
+        self.edit_notify(
+            view_id,
+            "gesture",
+            Some(json!({"line": line, "col": column, "ty": ty,})),
+        )
+    }
+
+    pub fn click_multi_word_select(
+        &mut self,
+        view_id: ViewId,
+        line: u64,
+        column: u64,
+    ) -> ClientResult<()> {
+        let ty = "multi_word_select";
+        self.edit_notify(
+            view_id,
+            "gesture",
+            Some(json!({"line": line, "col": column, "ty": ty,})),
+        )
+    }
+
     pub fn drag(&mut self, view_id: ViewId, line: u64, column: u64) -> ClientResult<()> {
         self.edit_notify(view_id, "drag", Some(json!([line, column, 0])))
     }


### PR DESCRIPTION
As 'click' and 'drag' are replaced by ['gesture'](https://xi-editor.io/docs/frontend-protocol.html#gesture), this adds wrapper functions for point_select, range_select, line_select, word_select, multi_line_select, multi_word_select

