### PR TITLE
Add support for measure_width

### DIFF
--- a/examples/it_works.rs
+++ b/examples/it_works.rs
@@ -5,9 +5,9 @@ extern crate xrl;
 
 use futures::{future, Future, Stream};
 use xrl::{
-    XiEvent,
+    XiNotification,
     Client, ServerResult, Frontend,
-    FrontendBuilder, spawn,
+    FrontendBuilder, spawn, MeasureWidth
 };
 
 
@@ -20,26 +20,31 @@ struct MyFrontend {
 // Implement how our client handles notifications and requests from the core.
 impl Frontend for MyFrontend {
 
-    fn handle_event(&mut self, ev: XiEvent) -> ServerResult<()> {
-        match ev {
-            XiEvent::Update(update) => println!("received `update` from Xi core:\n{:?}", update),
-            XiEvent::ScrollTo(scroll) => println!("received `scroll_to` from Xi core:\n{:?}", scroll),
-            XiEvent::DefStyle(style) => println!("received `def_style` from Xi core:\n{:?}", style),
-            XiEvent::AvailablePlugins(plugins) => println!("received `available_plugins` from Xi core:\n{:?}", plugins),
-            XiEvent::UpdateCmds(cmds) => println!("received `update_cmds` from Xi core:\n{:?}", cmds),
-            XiEvent::PluginStarted(plugin) => println!("received `plugin_started` from Xi core:\n{:?}", plugin),
-            XiEvent::PluginStoped(plugin) => println!("received `plugin_stoped` from Xi core:\n{:?}", plugin),
-            XiEvent::ConfigChanged(config) => println!("received `config_changed` from Xi core:\n{:?}", config),
-            XiEvent::ThemeChanged(theme) => println!("received `theme_changed` from Xi core:\n{:?}", theme),
-            XiEvent::Alert(alert) => println!("received `alert` from Xi core:\n{:?}", alert),
-            XiEvent::AvailableThemes(themes) => println!("received `available_themes` from Xi core:\n{:?}", themes),
-            XiEvent::FindStatus(status) => println!("received `find_status` from Xi core:\n{:?}", status),
-            XiEvent::ReplaceStatus(status) => println!("received `replace_status` from Xi core:\n{:?}", status),
-            XiEvent::MeasureWidth(request) => println!("received `measure_width` from Xi core:\n{:?}", request),
-            XiEvent::AvailableLanguages(langs) => println!("received `available_languages` from Xi core:\n{:?}", langs), 
-            XiEvent::LanguageChanged(lang) => println!("received `language_changed` from Xi core:\n{:?}", lang),
+    fn handle_notification(&mut self, notification: XiNotification) -> ServerResult<()> {
+        use XiNotification::*;
+
+        match notification {
+            Update(update) => println!("received `update` from Xi core:\n{:?}", update),
+            ScrollTo(scroll) => println!("received `scroll_to` from Xi core:\n{:?}", scroll),
+            DefStyle(style) => println!("received `def_style` from Xi core:\n{:?}", style),
+            AvailablePlugins(plugins) => println!("received `available_plugins` from Xi core:\n{:?}", plugins),
+            UpdateCmds(cmds) => println!("received `update_cmds` from Xi core:\n{:?}", cmds),
+            PluginStarted(plugin) => println!("received `plugin_started` from Xi core:\n{:?}", plugin),
+            PluginStoped(plugin) => println!("received `plugin_stoped` from Xi core:\n{:?}", plugin),
+            ConfigChanged(config) => println!("received `config_changed` from Xi core:\n{:?}", config),
+            ThemeChanged(theme) => println!("received `theme_changed` from Xi core:\n{:?}", theme),
+            Alert(alert) => println!("received `alert` from Xi core:\n{:?}", alert),
+            AvailableThemes(themes) => println!("received `available_themes` from Xi core:\n{:?}", themes),
+            FindStatus(status) => println!("received `find_status` from Xi core:\n{:?}", status),
+            ReplaceStatus(status) => println!("received `replace_status` from Xi core:\n{:?}", status),
+            AvailableLanguages(langs) => println!("received `available_languages` from Xi core:\n{:?}", langs),
+            LanguageChanged(lang) => println!("received `language_changed` from Xi core:\n{:?}", lang),
         }
         Box::new(future::ok(()))
+    }
+
+    fn handle_measure_width(&mut self, request: MeasureWidth) -> ServerResult<Vec<Vec<f32>>> {
+        Box::new(future::ok(Vec::new()))
     }
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -55,6 +55,7 @@ impl LineCache {
     }
 }
 
+#[derive(Debug)]
 struct UpdateHelper<'a, 'b, 'c> {
     old_lines: &'a mut Vec<Line>,
     old_invalid_before: &'b mut u64,
@@ -202,6 +203,9 @@ impl<'a, 'b, 'c> UpdateHelper<'a, 'b, 'c> {
     }
 
     fn update(mut self, operations: Vec<Operation>) {
+        trace!("updating the line cache");
+        trace!("cache state before: {:?}", &self);
+        trace!("operations to be applied: {:?}", &operations);
         for op in operations {
             match op.operation_type {
                 OperationType::Copy_ => (&mut self).apply_copy(op.nb_lines),

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use crate::structs::{ModifySelection, ViewId};
 
 /// A future returned by all the `Client`'s method.
-pub type ClientResult<T> = Box<Future<Item = T, Error = ClientError> + Send>;
+pub type ClientResult<T> = Box<dyn Future<Item = T, Error = ClientError> + Send>;
 
 /// A client to send notifications and request to xi-core.
 #[derive(Clone)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,7 +19,7 @@ pub enum ClientError {
 }
 
 impl fmt::Display for ClientError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ClientError::NotifyFailed => write!(f, "Failed to send a notification"),
             ClientError::RequestFailed => {
@@ -45,7 +45,7 @@ impl error::Error for ClientError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         if let ClientError::SerializeFailed(ref serde_error) = *self {
             Some(serde_error)
         } else {
@@ -68,7 +68,7 @@ pub enum ServerError {
 }
 
 impl fmt::Display for ServerError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ServerError::UnknownMethod(ref method) => write!(f, "Unkown method {}", method),
             ServerError::Other(ref s) => write!(f, "Unkown error: {}", s),
@@ -92,7 +92,7 @@ impl error::Error for ServerError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         if let ServerError::DeserializeFailed(ref serde_error) = *self {
             Some(serde_error)
         } else {

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -11,7 +11,7 @@ use crate::structs::{
     LanguageChanged
 };
 
-pub type ServerResult<T> = Box<Future<Item = T, Error = ServerError>>;
+pub type ServerResult<T> = Box<dyn Future<Item = T, Error = ServerError>>;
 
 /// Represents all possible RPC messages recieved from xi-core.
 #[derive(Debug)]
@@ -57,7 +57,7 @@ impl<F: Frontend + Send> Service for F {
         &mut self,
         method: &str,
         params: Value,
-    ) -> Box<Future<Item = Result<Self::T, Self::E>, Error = Self::Error>> {
+    ) -> Box<dyn Future<Item = Result<Self::T, Self::E>, Error = Self::Error>> {
         info!("<<< request: method={}, params={}", method, &params);
         match method {
             "measure_width" => match from_value::<MeasureWidth>(params) {
@@ -75,7 +75,7 @@ impl<F: Frontend + Send> Service for F {
         &mut self,
         method: &str,
         params: Value,
-    ) -> Box<Future<Item = (), Error = Self::Error>> {
+    ) -> Box<dyn Future<Item = (), Error = Self::Error>> {
         info!("<<< notification: method={}, params={}", method, &params);
         match method {
             "update" => match from_value::<Update>(params) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,26 +23,30 @@
 //! // Implement how our client handles notifications & requests from the core.
 //! impl Frontend for MyFrontend {
 //!
-//!     fn handle_event(&mut self, ev: XiEvent) -> ServerResult<()> {
-//!         match ev {
-//!             XiEvent::Update(update) => println!("received `update` from Xi core:\n{:?}", update),
-//!             XiEvent::ScrollTo(scroll) => println!("received `scroll_to` from Xi core:\n{:?}", scroll),
-//!             XiEvent::DefStyle(style) => println!("received `def_style` from Xi core:\n{:?}", style),
-//!             XiEvent::AvailablePlugins(plugins) => println!("received `available_plugins` from Xi core:\n{:?}", plugins),
-//!             XiEvent::UpdateCmds(cmds) => println!("received `update_cmds` from Xi core:\n{:?}", cmds),
-//!             XiEvent::PluginStarted(plugin) => println!("received `plugin_started` from Xi core:\n{:?}", plugin),
-//!             XiEvent::PluginStoped(plugin) => println!("received `plugin_stoped` from Xi core:\n{:?}", plugin),
-//!             XiEvent::ConfigChanged(config) => println!("received `config_changed` from Xi core:\n{:?}", config),
-//!             XiEvent::ThemeChanged(theme) => println!("received `theme_changed` from Xi core:\n{:?}", theme),
-//!             XiEvent::Alert(alert) => println!("received `alert` from Xi core:\n{:?}", alert),
-//!             XiEvent::AvailableThemes(themes) => println!("received `available_themes` from Xi core:\n{:?}", themes),
-//!             XiEvent::FindStatus(status) => println!("received `find_status` from Xi core:\n{:?}", status),
-//!             XiEvent::ReplaceStatus(status) => println!("received `replace_status` from Xi core:\n{:?}", status),
-//!             XiEvent::MeasureWidth(request) => println!("received `measure_width` from Xi core:\n{:?}", request),
-//!             XiEvent::AvailableLanguages(langs) => println!("received `available_languages` from Xi core:\n{:?}", langs), 
-//!             XiEvent::LanguageChanged(lang) => println!("received `language_changed` from Xi core:\n{:?}", lang),
+//!     fn handle_notification(&mut self, notification: XiNotification) -> ServerResult<()> {
+//!         use XiNotification::*;
+//!         match notification {
+//!             Update(update) => println!("received `update` from Xi core:\n{:?}", update),
+//!             ScrollTo(scroll) => println!("received `scroll_to` from Xi core:\n{:?}", scroll),
+//!             DefStyle(style) => println!("received `def_style` from Xi core:\n{:?}", style),
+//!             AvailablePlugins(plugins) => println!("received `available_plugins` from Xi core:\n{:?}", plugins),
+//!             UpdateCmds(cmds) => println!("received `update_cmds` from Xi core:\n{:?}", cmds),
+//!             PluginStarted(plugin) => println!("received `plugin_started` from Xi core:\n{:?}", plugin),
+//!             PluginStoped(plugin) => println!("received `plugin_stoped` from Xi core:\n{:?}", plugin),
+//!             ConfigChanged(config) => println!("received `config_changed` from Xi core:\n{:?}", config),
+//!             ThemeChanged(theme) => println!("received `theme_changed` from Xi core:\n{:?}", theme),
+//!             Alert(alert) => println!("received `alert` from Xi core:\n{:?}", alert),
+//!             AvailableThemes(themes) => println!("received `available_themes` from Xi core:\n{:?}", themes),
+//!             FindStatus(status) => println!("received `find_status` from Xi core:\n{:?}", status),
+//!             ReplaceStatus(status) => println!("received `replace_status` from Xi core:\n{:?}", status),
+//!             AvailableLanguages(langs) => println!("received `available_languages` from Xi core:\n{:?}", langs), 
+//!             LanguageChanged(lang) => println!("received `language_changed` from Xi core:\n{:?}", lang),
 //!         }
 //!         Box::new(future::ok(()))
+//!     }
+//!
+//!     fn handle_measure_width(&mut self, request: MeasureWidth) -> ServerResult<Vec<Vec<f32>>> {
+//!         Box::new(future::ok(Vec::new()))
 //!     }
 //! }
 //!
@@ -101,7 +105,7 @@ mod core;
 mod cache;
 
 pub use crate::cache::LineCache;
-pub use crate::frontend::{XiEvent, Frontend, FrontendBuilder, ServerResult};
+pub use crate::frontend::{XiNotification, Frontend, FrontendBuilder, ServerResult};
 pub use crate::client::{Client, ClientResult};
 pub use crate::errors::{ClientError, ServerError};
 pub use crate::core::{spawn, CoreStderr};
@@ -110,5 +114,5 @@ pub use crate::structs::{
     ThemeSettings, Query, Status, Alert, AvailableThemes, AvailableLanguages,
     UpdateCmds, ConfigChanged, ConfigChanges, ScrollTo, Position,
     Update, Style, Operation, OperationType, Line, StyleDef, LanguageChanged,
-    ViewId, ModifySelection, FindStatus, ReplaceStatus, MeasureWidth
+    ViewId, ModifySelection, FindStatus, ReplaceStatus, MeasureWidth,
 };

--- a/src/protocol/endpoint.rs
+++ b/src/protocol/endpoint.rs
@@ -23,19 +23,19 @@ pub trait Service: Send {
         &mut self,
         method: &str,
         params: Value,
-    ) -> Box<Future<Item = Result<Self::T, Self::E>, Error = Self::Error>>;
+    ) -> Box<dyn Future<Item = Result<Self::T, Self::E>, Error = Self::Error>>;
 
     fn handle_notification(
         &mut self,
         method: &str,
         params: Value,
-    ) -> Box<Future<Item = (), Error = Self::Error>>;
+    ) -> Box<dyn Future<Item = (), Error = Self::Error>>;
 }
 
 struct Server<S: Service + Send> {
     service: S,
-    request_tasks: HashMap<u64, Box<Future<Item = Result<S::T, S::E>, Error = S::Error>>>,
-    notification_tasks: Vec<Box<Future<Item = (), Error = S::Error>>>,
+    request_tasks: HashMap<u64, Box<dyn Future<Item = Result<S::T, S::E>, Error = S::Error>>>,
+    notification_tasks: Vec<Box<dyn Future<Item = (), Error = S::Error>>>,
 }
 
 unsafe impl <T: Service>Send for Server<T> {}

--- a/src/protocol/errors.rs
+++ b/src/protocol/errors.rs
@@ -13,7 +13,7 @@ pub enum DecodeError {
 }
 
 impl Display for DecodeError {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         Error::description(self).fmt(f)
     }
 }
@@ -30,7 +30,7 @@ impl Error for DecodeError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         if let DecodeError::Io(ref io_err) = *self {
             Some(io_err)
         } else {

--- a/src/protocol/errors.rs
+++ b/src/protocol/errors.rs
@@ -9,7 +9,6 @@ pub enum DecodeError {
     Truncated,
     Io(io::Error),
     InvalidJson,
-    InvalidMessage,
 }
 
 impl Display for DecodeError {
@@ -24,9 +23,6 @@ impl Error for DecodeError {
             DecodeError::Truncated => "not enough bytes to decode a complete message",
             DecodeError::Io(_) => "failure to read or write bytes on an IO stream",
             DecodeError::InvalidJson => "the byte sequence is not valid JSON",
-            DecodeError::InvalidMessage => {
-                "the byte sequence is valid JSON, but not a valid message"
-            }
         }
     }
 
@@ -49,6 +45,7 @@ impl From<SerdeError> for DecodeError {
     }
 }
 
+#[derive(Debug)]
 pub enum RpcError {
     ResponseCanceled,
     AckCanceled,

--- a/src/structs/config.rs
+++ b/src/structs/config.rs
@@ -6,12 +6,20 @@ pub struct ConfigChanged {
     pub changes: ConfigChanges
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ConfigChanges {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_face: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_size: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub line_ending: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub plugin_search_path: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tab_size: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub translate_tabs_to_spaces: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub word_wrap: Option<bool>,
 }

--- a/src/structs/view.rs
+++ b/src/structs/view.rs
@@ -95,7 +95,7 @@ impl <'de>Visitor<'de> for ViewVisitor {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct MeasureWidth(Vec<MeasureWidthInner>);
+pub struct MeasureWidth(pub Vec<MeasureWidthInner>);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MeasureWidthInner {

--- a/src/structs/view.rs
+++ b/src/structs/view.rs
@@ -27,7 +27,7 @@ impl From<ParseIntError> for IdParseError {
 }
 
 impl fmt::Display for IdParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.to_string())
     }
 }
@@ -60,7 +60,7 @@ impl FromStr for ViewId {
 }
 
 impl fmt::Display for ViewId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "view-id-{}",self.0)
     }
 }
@@ -83,7 +83,7 @@ struct ViewVisitor;
 
 impl <'de>Visitor<'de> for ViewVisitor {
     type Value = ViewId;
-    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("expecting a string in the form of `view-id-x`.")
     }
     fn visit_str<E: Error>(self, s: &str) -> Result<Self::Value, E>  {


### PR DESCRIPTION
This is based on https://github.com/xi-frontend/xrl/pull/24 so that @Cogitri can try it out if they want. Also note that I haven't tested it out yet because I'm not sure how to make xi-core to send me that specific request.

This is the first time we support _requests_ (as opposed to _notifications_) from the core.

I could not reuse `XiEvent` because unlike all the events we've been handling until now, we need to return something to the core. As a result, we cannot use `handle_event()`. As a result, I added a method to `Frontend`, and renamed `XiEvent` and `handle_event()` to `XiNotification` and `handle_notification()` respectively.

One thing that annoys me is that with requests, we'll be reproducing the issue described in https://github.com/xi-frontend/xrl/issues/21, because we'll add one method to the `Frontend` trait for each request with a distinct return type. For instance, here I added:

```rust
fn handle_measure_width(&mut self, request: MeasureWidthRequest) -> Box<Future<Item = MeasureWidthResponse, Error = ServerError>>;
```

One solution would be to only have one method called `handle_request`, and an enum `XiRequest` similar to the current `XiEvent`:

```rust
fn handle_measure_width(&mut self, request: XiRequest) -> Box<Future<Item = Value, Error = ServerError>>;
```

The problem is that we lose the strong typing on the return value, and implementors would have to convert their result into a `Value` which does not seem very nice.

What do you think @bytebuddha @Cogitri ?