### PR TITLE
feat(client): add request_lines rpc

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -605,5 +605,18 @@ impl Client {
         )
     }
 
+    pub fn request_lines(
+        &self,
+        view_id: ViewId,
+        first_line: u64,
+        last_line: u64,
+    ) -> ClientResult<()> {
+        self.edit_notify(
+            view_id,
+            "request_lines",
+            Some(json!([first_line, last_line])),
+        )
+    }
+
     // TODO: requests for plugin_rpc
 }


### PR DESCRIPTION
This is handy e.g. for prefetching lines to avoid flashing during drawing (in gxi's case it could happen that you scrolled down, saw a blank state and then saw lines appearing, which is pretty suboptimal).