### PR TITLE
refactor(core): don't panic if we can't find xi-core

### DIFF
--- a/examples/it_works.rs
+++ b/examples/it_works.rs
@@ -79,7 +79,7 @@ impl FrontendBuilder for MyFrontendBuilder {
 fn main() {
     tokio::run(future::lazy(move || {
         // spawn Xi core
-        let (client, core_stderr) = spawn("xi-core", MyFrontendBuilder {});
+        let (client, core_stderr) = spawn("xi-core", MyFrontendBuilder {}).unwrap();
 
         // start logging Xi core's stderr
         tokio::spawn(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@
 //! fn main() {
 //!     tokio::run(future::lazy(move || {
 //!         // spawn Xi core
-//!         let (client, core_stderr) = spawn("xi-core", MyFrontendBuilder {});
+//!         let (client, core_stderr) = spawn("xi-core", MyFrontendBuilder {}).unwrap();
 //!
 //!         // start logging Xi core's stderr
 //!         tokio::spawn(

--- a/src/protocol/endpoint.rs
+++ b/src/protocol/endpoint.rs
@@ -44,7 +44,7 @@ where
         trace!("flushing stream");
         match self.stream.poll_complete() {
             Ok(Async::Ready(())) => self.client.acknowledge_notifications(),
-            Ok(Async::NotReady) => return,
+            Ok(Async::NotReady) => (),
             Err(e) => panic!("Failed to flush the sink: {:?}", e),
         }
     }

--- a/src/protocol/transport.rs
+++ b/src/protocol/transport.rs
@@ -20,7 +20,7 @@ where
     pub fn send(&mut self, message: Message) {
         debug!("sending message to remote peer: {:?}", message);
         match self.start_send(message) {
-            Ok(AsyncSink::Ready) => return,
+            Ok(AsyncSink::Ready) => (),
             // FIXME: there should probably be a retry mechanism.
             Ok(AsyncSink::NotReady(_message)) => panic!("The sink is full."),
             Err(e) => panic!("An error occured while trying to send message: {:?}", e),


### PR DESCRIPTION
We should only panic for programming errors and it's possibly
that the user just forgot to install xi-core