### PR TITLE
fix(client): remove unneeded pub(in crate::r#mod) from Client::new

### DIFF
--- a/src/protocol/client.rs
+++ b/src/protocol/client.rs
@@ -217,7 +217,7 @@ pub struct Client {
 }
 
 impl Client {
-    pub(in crate::r#mod) fn new(
+    fn new(
         requests_tx: RequestTx,
         notifications_tx: NotificationTx,
         shutdown_tx: mpsc::UnboundedSender<()>,


### PR DESCRIPTION
We don't actually need this function to be public and it crashes rustc when
compiling docs

fixes #36