### PR TITLE
Allow custom xi-core command

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -61,8 +61,20 @@ where
     F: Frontend + 'static + Send,
     B: FrontendBuilder<Frontend = F> + 'static,
 {
+    spawn_command(Command::new(executable), builder)
+}
+
+/// Same as [`spawn`] but accepts an arbitrary [`std::process::Command`].
+pub fn spawn_command<B, F>(
+    mut command: Command,
+    builder: B,
+) -> Result<(Client, CoreStderr), ClientError>
+where
+    F: Frontend + 'static + Send,
+    B: FrontendBuilder<Frontend = F> + 'static,
+{
     info!("starting xi-core");
-    let mut xi_core = Command::new(executable)
+    let mut xi_core = command
         .stdout(Stdio::piped())
         .stdin(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ mod structs;
 
 pub use crate::cache::LineCache;
 pub use crate::client::Client;
-pub use crate::core::{spawn, CoreStderr};
+pub use crate::core::{spawn, spawn_command, CoreStderr};
 pub use crate::errors::{ClientError, ServerError};
 pub use crate::frontend::{Frontend, FrontendBuilder, XiNotification};
 pub use crate::protocol::IntoStaticFuture;


### PR DESCRIPTION
Provide a way to use a custom command to make direct usage of `xi-core-lib` easier.